### PR TITLE
Add animated light-blue gradient background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -67,6 +67,32 @@ body {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    /* Keep default foreground coloring via Tailwind variable */
+    @apply text-foreground;
+
+    /* Light blue gradient background with a subtle animated shift */
+    background: linear-gradient(135deg, #d7ecff 0%, #e9f5ff 50%, #ffffff 100%);
+    background-size: 400% 400%;
+    animation: gradient-animation 15s ease infinite;
+  }
+
+  /* Override in dark mode to keep things readable */
+  .dark body {
+    @apply bg-background;
+    background-image: none;
+    animation: none;
   }
 }
+
+@keyframes gradient-animation {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+


### PR DESCRIPTION
### What & Why
Adds a tasteful light-blue gradient background with a subtle animation as requested in the issue *“Background”*.  

### Details
* Updated **app/globals.css**:
  * Keeps all existing CSS tokens intact.
  * Applies a linear-gradient background in light mode.
  * Uses `background-size: 400% 400%` plus an `@keyframes` loop to slowly pan the gradient for a modern feel.
  * Dark mode falls back to the existing solid color to preserve readability.

No other files were affected.

### Visual
The gradient starts with a very light sky-blue (`#d7ecff`), transitions through an even lighter hue, and fades to white, creating depth while remaining subtle. The animation cycle is 15 s, easing in and out infinitely.

---
Label: AI generated

Closes #12