### PR TITLE
Add splashy Intro section highlighting Young & AI experience

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,15 @@
+import Intro from "@/components/Intro"
 import Section from "@/components/Section"
 import { sectionData } from "@/data/mockData"
 
 export default function Home() {
   return (
     <main className="container mx-auto px-4">
+      <Intro />
       {sectionData.map((section) => (
         <Section key={section.title} data={section} />
       ))}
     </main>
   )
 }
+

--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -1,0 +1,17 @@
+export default function Intro() {
+  return (
+    <section className="w-full py-24 md:py-32 lg:py-40 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white mb-12 rounded-lg shadow-lg">
+      <div className="container mx-auto px-4 flex flex-col items-center">
+        <h1 className="text-4xl md:text-5xl lg:text-6xl font-extrabold text-center leading-tight drop-shadow-lg">
+          Young & AI
+        </h1>
+        <p className="mt-6 max-w-3xl text-center text-lg md:text-xl lg:text-2xl font-medium">
+          We’ve been helping companies build cutting-edge AI and automation solutions since <span className="font-bold">2018</span>.
+          <br className="hidden md:block" />
+          From multi-agent architectures to dazzling product experiences, our team turns bold ideas into reality.
+        </p>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
### What
Adds a new `Intro` component and inserts it at the top of the home page.  The section features a bold gradient background and copy that communicates that **Young & AI** has been helping companies build AI & automation solutions since 2018.

### Why
Closes issue: "Intro – Add an introduction section about young and AI. We’ve been helping companies build AI and automation solutions since 2018. Make it cool and splashy"

### How
* Created `components/Intro.tsx` containing the styled marketing splash section.
* Updated `app/page.tsx` to render `<Intro />` above the existing lists.

No other files were touched.  The change is fully isolated and does not introduce any new dependencies.

Closes #14