### PR TITLE
Add splashy intro hero for Young & AI

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,17 @@
 import Section from "@/components/Section"
 import { sectionData } from "@/data/mockData"
+import HeroIntro from "@/components/HeroIntro"
 
 export default function Home() {
   return (
-    <main className="container mx-auto px-4">
-      {sectionData.map((section) => (
-        <Section key={section.title} data={section} />
-      ))}
+    <main>
+      <HeroIntro />
+      <div className="container mx-auto px-4">
+        {sectionData.map((section) => (
+          <Section key={section.title} data={section} />
+        ))}
+      </div>
     </main>
   )
 }
+

--- a/components/HeroIntro.tsx
+++ b/components/HeroIntro.tsx
@@ -1,0 +1,63 @@
+import Image from "next/image"
+import Link from "next/link"
+
+export default function HeroIntro() {
+  return (
+    <section className="relative overflow-hidden">
+      {/* Splashy gradient background */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10"
+      >
+        <div className="absolute -top-24 -left-24 h-96 w-96 rounded-full bg-gradient-to-br from-cyan-400/30 via-fuchsia-500/20 to-emerald-400/20 blur-3xl" />
+        <div className="absolute -bottom-24 -right-24 h-[28rem] w-[28rem] rounded-full bg-gradient-to-tr from-emerald-400/20 via-cyan-400/20 to-fuchsia-500/30 blur-3xl" />
+        <div className="absolute left-1/2 top-1/2 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/10 blur-2xl" />
+      </div>
+
+      <div className="container mx-auto px-4">
+        <div className="grid grid-cols-1 items-center gap-10 py-16 md:grid-cols-2 md:py-24">
+          <div>
+            <h1 className="text-4xl font-bold leading-tight tracking-tight sm:text-5xl md:text-6xl">
+              Young &
+              <span className="ml-3 bg-gradient-to-r from-cyan-300 via-emerald-300 to-fuchsia-300 bg-clip-text text-transparent">
+                AI
+              </span>
+            </h1>
+            <p className="mt-6 max-w-xl text-lg text-muted-foreground">
+              We’ve been helping companies build AI and automation solutions since
+              2018.
+            </p>
+
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="#client-work"
+                className="inline-flex items-center rounded-md bg-white/10 px-5 py-2.5 text-sm font-medium text-white shadow-sm ring-1 ring-inset ring-white/20 backdrop-blur transition-colors hover:bg-white/20"
+              >
+                See our work
+              </Link>
+              <Link
+                href="#talks"
+                className="inline-flex items-center rounded-md bg-transparent px-5 py-2.5 text-sm font-medium text-white ring-1 ring-inset ring-white/30 transition-colors hover:bg-white/10"
+              >
+                Talks & workshops
+              </Link>
+            </div>
+          </div>
+
+          <div className="relative mx-auto flex h-64 w-64 items-center justify-center md:h-80 md:w-80">
+            <div className="absolute inset-0 animate-pulse rounded-full bg-gradient-to-tr from-fuchsia-400/15 via-cyan-400/15 to-emerald-400/15 blur-2xl" />
+            <Image
+              src="/globe.svg"
+              alt="Globe"
+              width={256}
+              height={256}
+              className="relative drop-shadow-[0_0_35px_rgba(56,189,248,0.25)]"
+              priority
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,6 +1,13 @@
 import { SectionData } from "@/data/mockData"
 import Link from "next/link"
 
+function slugify(input: string) {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+}
+
 export default function Section({ data }: { data: SectionData }) {
   const displayItems = data.items.slice(0, 5)
 
@@ -16,19 +23,19 @@ export default function Section({ data }: { data: SectionData }) {
   }
 
   return (
-    <section className="mb-12">
-      <div className="flex justify-between items-center mb-4">
+    <section id={slugify(data.title)} className="mb-12">
+      <div className="mb-4 flex items-center justify-between">
         <h2 className="text-2xl font-semibold">{data.title}</h2>
       </div>
       <div className="relative">
-        <div className="flex overflow-x-auto space-x-4 pb-4 scrollbar-hide">
+        <div className="scrollbar-hide flex overflow-x-auto space-x-4 pb-4">
           {displayItems.map((item) => (
             <Link key={item.id} href={getItemHref(item)} passHref>
-              <div className="flex-none w-64 bg-card p-4 rounded-lg shadow-md cursor-pointer transition-transform hover:scale-105">
-                <h3 className="font-medium text-lg mb-2 text-card-foreground">
+              <div className="w-64 flex-none cursor-pointer rounded-lg bg-card p-4 shadow-md transition-transform hover:scale-105">
+                <h3 className="mb-2 text-lg font-medium text-card-foreground">
                   {item.title}
                 </h3>
-                <p className="text-sm truncate text-muted-foreground">
+                <p className="truncate text-sm text-muted-foreground">
                   {item.description}
                 </p>
               </div>
@@ -39,3 +46,4 @@ export default function Section({ data }: { data: SectionData }) {
     </section>
   )
 }
+


### PR DESCRIPTION
This PR adds an introduction section to the homepage as requested.

What’s included:
- New HeroIntro component with a bold headline and tagline: “We’ve been helping companies build AI and automation solutions since 2018.”
- Splashy gradient visuals and a globe accent for a modern, energetic feel
- Clear CTAs linking to the Client Work and Talks sections
- Section component updated to expose stable anchor IDs via slugified titles (e.g., #client-work, #talks) so the hero buttons can scroll to the relevant sections
- Homepage updated to render the new hero above existing sections

Notes:
- No external dependencies added; styling uses Tailwind utilities already in the project.
- Linting passes with no issues (`next lint`).

Let me know if you’d like alternative visuals, copy tweaks, or different CTA targets.

Closes #14