### PR TITLE
Add subtle animated gradient background that drifts on scroll

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import localFont from "next/font/local"
 import { Rokkitt } from "next/font/google"
 import "./globals.css"
+import BackgroundGradient from "@/components/BackgroundGradient"
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -34,8 +35,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${rokkitt.className} antialiased`}
       >
-        {children}
+        {/* Site-wide subtle animated gradient backdrop */}
+        <BackgroundGradient />
+        <div className="relative z-10">{children}</div>
       </body>
     </html>
   )
 }
+

--- a/components/BackgroundGradient.tsx
+++ b/components/BackgroundGradient.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+/**
+ * Fixed, full-viewport gradient backdrop that subtly drifts as you scroll.
+ *
+ * - Uses requestAnimationFrame + passive scroll listener for perf
+ * - Respects prefers-reduced-motion
+ * - Translates a slightly oversized layer so edges never show
+ * - Ultra-low alpha colors to keep it tasteful on dark backgrounds
+ */
+export default function BackgroundGradient() {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const prefersReduced = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches
+
+    if (prefersReduced) {
+      // Keep static if user prefers reduced motion
+      el.style.transform = "translate3d(0,0,0) scale(1.05)"
+      return
+    }
+
+    let ticking = false
+
+    const onScroll = () => {
+      if (ticking) return
+      ticking = true
+      requestAnimationFrame(() => {
+        const y = window.scrollY || 0
+        // Create a slow, subtle drift that feels responsive to scroll
+        const tx = Math.sin(y / 1200) * 40 // px
+        const ty = Math.cos(y / 1000) * 60 // px
+        el.style.transform = `translate3d(${tx.toFixed(2)}px, ${ty.toFixed(2)}px, 0) scale(1.05)`
+        ticking = false
+      })
+    }
+
+    // Initialize position once
+    onScroll()
+
+    window.addEventListener("scroll", onScroll, { passive: true })
+    return () => {
+      window.removeEventListener("scroll", onScroll)
+    }
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-0"
+      style={{
+        // Slightly oversize to avoid showing edges during transform
+        top: "-10%",
+        left: "-10%",
+        width: "120%",
+        height: "120%",
+        willChange: "transform",
+        backgroundImage: [
+          // Emerald glow
+          "radial-gradient(600px 400px at 12% 18%, rgba(16,185,129,0.15), rgba(16,185,129,0) 60%)",
+          // Cyan glow
+          "radial-gradient(520px 520px at 85% 28%, rgba(6,182,212,0.14), rgba(6,182,212,0) 65%)",
+          // Indigo base depth
+          "radial-gradient(700px 520px at 30% 85%, rgba(99,102,241,0.10), rgba(99,102,241,0) 60%)",
+          // Soft vertical sheen
+          "linear-gradient(180deg, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.00) 30%)",
+        ].join(","),
+        backgroundRepeat: "no-repeat",
+        backgroundSize: "cover, cover, cover, cover",
+        filter: "saturate(1.1)",
+      }}
+    />
+  )
+}
+


### PR DESCRIPTION
This PR implements a site-wide, subtle animated gradient backdrop as requested.

What’s included
- New BackgroundGradient client component:
  - Fixed, full-viewport multi-layer radial gradients with soft, tasteful colors that complement the existing palette
  - Smooth, subtle drift tied to scroll using requestAnimationFrame for good performance
  - Respects prefers-reduced-motion for accessibility
  - Oversized layer and GPU-accelerated transforms to avoid edge artifacts
- Integrated globally in app/layout.tsx, placed behind all content via a z-indexed wrapper so it doesn’t interfere with layout or interactivity

Implementation details
- The gradient uses ultra-low alpha emerald/cyan/indigo glows plus a soft vertical sheen to enhance depth, sitting on top of the existing dark background color.
- Motion is very subtle (sin/cos based offsets), creating a sense of movement as the user scrolls rather than an attention-grabbing animation.
- The entire app content is wrapped in a relative z-10 container to ensure all page elements (including existing hero accents) render above the backdrop.

Dev notes
- Linting passes with no issues.
- No breaking changes to component APIs or pages.

If you’d like the motion to be even more/less pronounced or prefer different hue/positions for the glows, I can tune the colors and math constants easily.

Closes #16