### PR TITLE
Add intro section after hero on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 import Section from "@/components/Section"
 import Hero from "@/components/Hero"
+import Intro from "@/components/Intro"
 import { sectionData } from "@/data/mockData"
 
 export default function Home() {
   return (
     <>
       <Hero />
+      <Intro />
       <main className="container mx-auto px-4">
         {sectionData.map((section) => (
           <Section key={section.title} data={section} />

--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -1,0 +1,20 @@
+export default function Intro() {
+  return (
+    <section className="border-t border-white/10">
+      <div className="container mx-auto px-4 py-12 md:py-16">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-lg leading-relaxed text-white/80 md:text-xl">
+            <span className="font-semibold text-white">Young & AI</span> builds AI products and solutions for enterprises and startups alike.
+          </p>
+          <p className="mt-4 text-base leading-relaxed text-white/70 md:text-lg">
+            From rapid prototypes to production systems, we partner with teams to design, implement, and ship applied AI that solves real business problems.
+          </p>
+          <p className="mt-2 text-base leading-relaxed text-white/70 md:text-lg">
+            Our work spans automation, integrations, and data platforms—bringing measurable impact with pragmatic, reliable engineering.
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
This PR adds a new Intro section that appears directly after the Hero on the landing page.

What’s included:
- New components/Intro.tsx: a concise introduction explaining what Young & AI does in 2–3 short sentences.
- Updated app/page.tsx to render the Intro component right after the Hero.
- Styling aligns with the existing design system (Tailwind) and maintains readability on the dark theme.

Why:
- Addresses the request to quickly introduce the company on the landing page immediately after the hero.

QA:
- Ran `npm ci` and `npm run lint` — no lint errors.
- Visit `/` and verify the Intro section appears below the Hero and above the rest of the content.

Copy used:
- “Young & AI builds AI products and solutions for enterprises and startups alike.”
- “From rapid prototypes to production systems, we partner with teams to design, implement, and ship applied AI that solves real business problems.”
- “Our work spans automation, integrations, and data platforms—bringing measurable impact with pragmatic, reliable engineering.”

Closes #22