### PR TITLE
Redesign hero section with bold left-aligned headline

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,37 +1,12 @@
 export default function Hero() {
   return (
-    <section className="relative overflow-hidden">
-      {/* Splashy background accents */}
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -top-24 -left-24 h-80 w-80 rounded-full bg-gradient-to-br from-emerald-400/30 via-teal-400/20 to-cyan-400/10 blur-3xl" />
-        <div className="absolute -bottom-24 -right-24 h-96 w-96 rounded-full bg-gradient-to-tr from-cyan-400/30 via-sky-400/20 to-indigo-400/10 blur-3xl" />
-        <div className="absolute left-1/2 top-1/2 h-48 w-48 -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-to-br from-white/10 to-transparent blur-2xl" />
-      </div>
-
+    <section className="min-h-[85vh] flex items-start">
       <div className="container mx-auto px-4 py-20 md:py-28 lg:py-32">
-        <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs uppercase tracking-wider text-white/80 backdrop-blur">
-          <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
-          Building with AI since 2018
-        </p>
-        <h1 className="text-balance text-4xl font-extrabold leading-tight md:text-6xl lg:text-7xl">
-          <span className="bg-gradient-to-r from-emerald-200 via-teal-200 to-cyan-200 bg-clip-text text-transparent">
-            Young & AI
-          </span>
-        </h1>
-        <p className="mt-4 max-w-2xl text-lg text-white/80 md:mt-6 md:text-2xl">
-          We’ve been helping companies build AI and automation solutions since
-          2018.
-        </p>
-        <div className="mt-8 flex flex-wrap gap-3">
-          <span className="rounded-md border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/80">
-            Applied AI
-          </span>
-          <span className="rounded-md border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/80">
-            Automation
-          </span>
-          <span className="rounded-md border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/80">
-            Data & MLOps
-          </span>
+        <div className="space-y-3 text-left">
+          <p className="text-sm md:text-base text-white/70">Young and AI</p>
+          <h1 className="font-extrabold tracking-tight leading-[0.9] text-[clamp(2.75rem,10vw,10rem)]">
+            we build AI
+          </h1>
         </div>
       </div>
     </section>


### PR DESCRIPTION
This PR updates the hero section to a simpler, clearer presentation per the request:

- Company name "Young and AI" appears above the headline, left-aligned in a smaller font.
- Main headline changed to "we build AI" in very large, bold type.
- Layout is left-aligned and designed to occupy most of the viewport height for immediate impact.
- Removed previous decorative background and badges to keep the hero minimal.
- Responsive sizing via CSS clamp ensures the headline scales cleanly across screen sizes.

Files changed:
- components/Hero.tsx

Notes:
- A PR already existed for a similarly named branch; this version ensures we can open a new PR cleanly while matching the requested design.

Happy to adjust vertical alignment (top vs center) or font sizes if you prefer a different feel.

Closes #19