### PR TITLE
Replace Client Work scroll with Featured Client Projects section

### DIFF
--- a/app/client/page.tsx
+++ b/app/client/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link"
+import { sectionData } from "@/data/mockData"
+
+export default function ClientIndexPage() {
+  const clientSection = sectionData.find((s) => s.title === "Client Work")
+  const items = clientSection?.items ?? []
+
+  return (
+    <main className="container mx-auto px-4 py-12">
+      <h1 className="text-3xl font-semibold mb-8">Client Projects</h1>
+      <p className="text-muted-foreground mb-8">
+        A selection of client projects showcasing engineering, product, and AI work.
+      </p>
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {items.map((item) => (
+          <Link key={item.id} href={`/client/${item.slug}`} className="block">
+            <div className="h-full bg-card p-5 rounded-lg shadow-md transition-transform hover:scale-[1.02]">
+              <h2 className="font-medium text-lg mb-2 text-card-foreground">
+                {item.title}
+              </h2>
+              <p className="text-sm line-clamp-4 text-muted-foreground">
+                {item.description}
+              </p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </main>
+  )
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,14 +2,18 @@ import Section from "@/components/Section"
 import Hero from "@/components/Hero"
 import Intro from "@/components/Intro"
 import { sectionData } from "@/data/mockData"
+import FeaturedClientProjects from "@/components/FeaturedClientProjects"
 
 export default function Home() {
+  const otherSections = sectionData.filter((s) => s.title !== "Client Work")
+
   return (
     <>
       <Hero />
       <Intro />
+      <FeaturedClientProjects />
       <main className="container mx-auto px-4">
-        {sectionData.map((section) => (
+        {otherSections.map((section) => (
           <Section key={section.title} data={section} />
         ))}
       </main>

--- a/components/FeaturedClientProjects.tsx
+++ b/components/FeaturedClientProjects.tsx
@@ -1,0 +1,62 @@
+import Image from "next/image"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { sectionData } from "@/data/mockData"
+
+export default function FeaturedClientProjects() {
+  const clientSection = sectionData.find((s) => s.title === "Client Work")
+  const items = clientSection ? clientSection.items.slice(0, 3) : []
+
+  // Map known slugs to representative images in /public
+  const imageForSlug: Record<string, string> = {
+    "nextjs-publication": "/next.svg",
+    "multi-agent-rag-architecture": "/globe.svg",
+    "mlops-health-tech-marketplace": "/window.svg",
+  }
+
+  if (items.length === 0) return null
+
+  return (
+    <section className="container mx-auto px-4 py-12">
+      <h2 className="text-3xl font-semibold mb-10">Featured Client Projects</h2>
+
+      <div className="space-y-16">
+        {items.map((item, idx) => {
+          const isImageLeft = idx % 2 === 0
+          const imageSrc = imageForSlug[item.slug] ?? "/file.svg"
+
+          return (
+            <div key={item.id} className="grid md:grid-cols-2 gap-8 items-center">
+              <div className={cn(isImageLeft ? "" : "md:order-2")}>
+                <Link href={`/client/${item.slug}`}>
+                  <Image
+                    src={imageSrc}
+                    alt={item.title}
+                    width={800}
+                    height={600}
+                    className="w-full h-auto rounded-lg border bg-card"
+                  />
+                </Link>
+              </div>
+              <div className={cn(isImageLeft ? "" : "md:order-1")}>
+                <h3 className="text-2xl font-medium mb-3">{item.title}</h3>
+                <p className="text-muted-foreground mb-6">{item.description}</p>
+                <Button asChild variant="outline">
+                  <Link href={`/client/${item.slug}`}>Read case study</Link>
+                </Button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="mt-14 flex justify-center">
+        <Button asChild size="lg">
+          <Link href="/client">Learn more</Link>
+        </Button>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
This PR replaces the horizontal scroll used for the "Client Work" section on the home page with a new, dedicated Featured Client Projects section, and adds a /client index page listing all client projects.

What’s included:
- New component: components/FeaturedClientProjects.tsx
  - Highlights three client projects with an alternating layout (image left/text right, then flipped, etc.).
  - Uses representative images from /public for visual context.
  - Includes a call-to-action button at the bottom ("Learn more") centered and linking to the full client projects list.
- Home page update (app/page.tsx)
  - Renders <FeaturedClientProjects />
  - Excludes the original "Client Work" section from the generic horizontal scroll sections.
- New /client index page (app/client/page.tsx)
  - Lists all client projects with titles and descriptions, linking to each project’s detail page at /client/[slug].

Notes:
- The Featured section currently pulls the first three items from the existing Client Work data in data/mockData.ts, so no new data model is introduced.
- Styling is consistent with the project’s Tailwind + shadcn UI approach (Button, layout spacing, etc.).
- Linting passes with `npm run lint`.

If you want different images or exact copy for the CTA (e.g., "Read more" vs. "Learn more"), I can easily adjust. Let me know if you’d prefer this component to live under a different folder (e.g., components/sections).

Closes #24