### PR TITLE
Add Community & Events section highlighting weekly AI breakfasts in Shanghai

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 import Hero from "@/components/Hero"
 import Intro from "@/components/Intro"
+import Community from "@/components/Community"
 
 export default function Home() {
   return (
     <>
       <Hero />
       <Intro />
+      <Community />
     </>
   )
 }

--- a/components/Community.tsx
+++ b/components/Community.tsx
@@ -1,0 +1,33 @@
+import { Mail } from "lucide-react"
+
+export default function Community() {
+  return (
+    <section className="border-t border-primary/10 py-20 px-4">
+      <div className="container mx-auto">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-3xl md:text-5xl font-semibold tracking-tight">Community & Events</h2>
+          <p className="mt-6 text-xl leading-relaxed md:text-2xl text-muted-foreground">
+            Every Thursday in Shanghai, I host an AI Breakfast—a casual, high-signal meetup where founders, engineers, and operators trade notes on what&#39;s new and what&#39;s working.
+          </p>
+          <p className="mt-4 text-lg leading-relaxed md:text-xl text-muted-foreground">
+            We dive into the latest advancements, compare real-world AI workflows we&#39;ve built, and share how AI is changing our day-to-day work and personal lives. It&#39;s practical, open, and focused on shipping.
+          </p>
+          <p className="mt-4 text-lg leading-relaxed md:text-xl text-muted-foreground">
+            Visiting Shanghai on a Thursday? Join us—would love to have you at the table.
+          </p>
+          <div className="mt-10">
+            <a
+              href="mailto:contact@youngandai.com?subject=AI%20Breakfast%20in%20Shanghai"
+              aria-label="Email to join AI Breakfast in Shanghai"
+              className="inline-flex items-center gap-3 rounded-full border border-foreground/20 px-5 py-3 hover:bg-foreground/5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-foreground/30 transition"
+            >
+              <Mail className="w-5 h-5" />
+              <span className="text-base md:text-lg">RSVP for Thursday&#39;s AI Breakfast</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
Summary
- Adds a new “Community & Events” section to the bottom of the homepage.
- Highlights our weekly AI Breakfasts every Thursday in Shanghai, what we cover, and that they are hosted by us to underscore active involvement in the AI community.
- Includes an RSVP mailto call-to-action.

Details
- New component: components/Community.tsx with concise copy:
  - Emphasizes weekly Thursday AI Breakfast meetups in Shanghai.
  - Mentions we share latest advancements, practical workflows, and day-to-day AI applications.
  - Makes it clear that the breakfasts are hosted by us, subtly reinforcing credibility and community presence.
- Home page update: app/page.tsx imports and renders <Community /> after <Intro /> so it appears at the bottom of the main page.
- Styling follows existing patterns (container widths, spacing, border-top, typography) and passes Next.js ESLint rules.

Why
Addresses the request to communicate that Young & AI is actively engaged with the AI community, without stating it explicitly. The section reads like a typical company page events/community blurb, but frames the group as hands-on and practitioner-oriented.

Notes
- Copy is minimal and approachable. Happy to tweak the tone, add a location/time blurb, or link to a calendar/event page if desired.
- Lint passes with `npm run lint`. No other files changed.

Closes #27