### PR TITLE
Rename section to AI Breakfast, update wording to “we”, and increase height

### DIFF
--- a/components/Community.tsx
+++ b/components/Community.tsx
@@ -2,18 +2,18 @@ import { Mail } from "lucide-react"
 
 export default function Community() {
   return (
-    <section className="border-t border-primary/10 py-20 px-4">
+    <section className="border-t border-primary/10 py-20 px-4 min-h-[60vh]">
       <div className="container mx-auto">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-3xl md:text-5xl font-semibold tracking-tight">Community & Events</h2>
+          <h2 className="text-3xl md:text-5xl font-semibold tracking-tight">AI Breakfast</h2>
           <p className="mt-6 text-xl leading-relaxed md:text-2xl text-muted-foreground">
-            Every Thursday in Shanghai, I host an AI Breakfast—a casual, high-signal meetup where founders, engineers, and operators trade notes on what&#39;s new and what&#39;s working.
+            Every Thursday in Shanghai, we host AI Breakfast—a casual, high-signal meetup where founders, engineers, and operators trade notes on what&#39;s new and what&#39;s working.
           </p>
           <p className="mt-4 text-lg leading-relaxed md:text-xl text-muted-foreground">
             We dive into the latest advancements, compare real-world AI workflows we&#39;ve built, and share how AI is changing our day-to-day work and personal lives. It&#39;s practical, open, and focused on shipping.
           </p>
           <p className="mt-4 text-lg leading-relaxed md:text-xl text-muted-foreground">
-            Visiting Shanghai on a Thursday? Join us—would love to have you at the table.
+            Visiting Shanghai on a Thursday? Join us—we&#39;d love to have you at the table.
           </p>
           <div className="mt-10">
             <a


### PR DESCRIPTION
This PR addresses the requested updates to the Community & Events section:

- Renames the section header to “AI Breakfast”.
- Updates wording to avoid first-person singular and use team-focused language (“we”).
- Increases the section height to be taller (~60% of the viewport height) for better visual balance.

Implementation details:
- components/Community.tsx
  - Header changed from “Community & Events” to “AI Breakfast”.
  - First paragraph rewritten to "Every Thursday in Shanghai, we host AI Breakfast..."
  - Closing sentence updated to "we'd love to have you at the table."
  - Added Tailwind class `min-h-[60vh]` to the section for increased height.

Linting:
- Ran `npm install` and `npm run lint` locally; no ESLint warnings or errors.

Let me know if you prefer 50vh instead of 60vh and I can adjust easily.

Closes #29