### PR TITLE
Prevent hero text from overlapping logo on short screens

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,6 +1,6 @@
 export default function Hero() {
   return (
-    <section className="relative min-h-[90dvh] grid place-items-center px-4">
+    <section className="relative min-h-[100dvh] grid place-items-center px-4 pt-24 sm:pt-28 md:pt-32">
       <div className="absolute w-full  top-16 md:left-8 md:top-16 text-2xl md:text-3xl text-center">
         <p className="text-2xl md:text-3xl">Young & AI</p>
       </div>
@@ -12,3 +12,4 @@ export default function Hero() {
     </section>
   )
 }
+


### PR DESCRIPTION
This PR addresses the issue where the hero headline could overlap the "Young & AI" logo on very short screens.

Changes
- Add responsive top padding to the hero section (pt-24 sm:pt-28 md:pt-32) to reserve space for the absolutely positioned logo.
- Increase the hero's minimum height from 90dvh to 100dvh to provide more vertical space on short viewports.

Why
- Ensures the “WE BUILD AI” headline always sits below the logo and never overlaps.
- Maintains current design while treating the previous height as a minimum baseline, per the request.

QA
- Verify on very short/landscape mobile screens that the headline no longer overlaps the logo.
- Check multiple breakpoints to confirm spacing looks balanced.

Linting
- Ran pnpm install and pnpm run lint. ESLint reports no warnings or errors.

Closes #31