### PR TITLE
Prevent hero text from overlapping logo on short screens

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,14 +1,17 @@
 export default function Hero() {
   return (
-    <section className="relative min-h-[90dvh] grid place-items-center px-4">
-      <div className="absolute w-full  top-16 md:left-8 md:top-16 text-2xl md:text-3xl text-center">
+    <section className="relative min-h-[100svh] flex flex-col px-4">
+      <div className="w-full pt-16 md:pt-16 text-center">
         <p className="text-2xl md:text-3xl">Young & AI</p>
       </div>
-      <h1 className="font-extrabold tracking-[-0.02em] leading-[0.82] text-center text-[clamp(2.5rem,20vmin,12rem)]">
-        <span className="block">WE</span>
-        <span className="block">BUILD</span>
-        <span className="block text-primary text-[clamp(2.5rem,50vmin,30rem)]">AI</span>
-      </h1>
+      <div className="flex-1 grid place-items-center">
+        <h1 className="font-extrabold tracking-[-0.02em] leading-[0.82] text-center text-[clamp(2.5rem,20vmin,12rem)]">
+          <span className="block">WE</span>
+          <span className="block">BUILD</span>
+          <span className="block text-primary text-[clamp(2.5rem,50vmin,30rem)]">AI</span>
+        </h1>
+      </div>
     </section>
   )
 }
+


### PR DESCRIPTION
Problem
On short screens, the hero headline (WE BUILD AI) overlapped the Young & AI logo because the logo was absolutely positioned and didn’t participate in layout flow.

What I changed
- Reworked Hero layout to avoid overlap without changing the existing visual style more than necessary.
- Moved the logo into the normal document flow and reserved space for it at the top with padding.
- Centered the hero headline within the remaining space using a flexible layout.
- Increased hero section minimum height to 100svh to better accommodate very short screens and mobile safe areas.

Implementation details
- Section now uses flex column with min-h-[100svh] and px-4.
- Top logo area uses pt-16 to maintain spacing from the top like the previous top-16 absolute positioning.
- The headline is wrapped in a flex-1 container with grid place-items-center so it centers in the remaining space and never overlaps the logo.

Why this works
- Because the logo is no longer absolutely positioned, it always occupies its own space above the headline.
- Even on very short screens, the hero can grow taller (min height, not fixed), ensuring separation instead of overlap.

Verification
- Ran linting via `pnpm run lint` (Next.js ESLint). No warnings or errors.

Notes
- I preserved the existing typography and sizing (including clamp/vmin values) to keep the intended design, while ensuring proper separation.


Closes #31