### PR TITLE
Add Issue to PR section before AI Breakfast

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Hero from "@/components/Hero"
 import Intro from "@/components/Intro"
+import IssueToPR from "@/components/IssueToPR"
 import Community from "@/components/Community"
 
 export default function Home() {
@@ -7,6 +8,7 @@ export default function Home() {
     <>
       <Hero />
       <Intro />
+      <IssueToPR />
       <Community />
     </>
   )

--- a/components/IssueToPR.tsx
+++ b/components/IssueToPR.tsx
@@ -1,0 +1,29 @@
+import { ArrowUpRight } from "lucide-react"
+
+export default function IssueToPR() {
+  return (
+    <section className="border-t border-primary/10 py-20 px-4">
+      <div className="container mx-auto">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-3xl md:text-5xl font-semibold tracking-tight">Issue to PR</h2>
+          <p className="mt-6 text-xl leading-relaxed md:text-2xl text-muted-foreground">
+            Issue to PR is an automated way to generate code for a GitHub issue and create pull requests. Describe the problem once, and let it draft focused changes and open PRs you can review and ship.
+          </p>
+          <div className="mt-10">
+            <a
+              href="https://issuetopr.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Visit issuetopr.dev"
+              className="inline-flex items-center gap-3 rounded-full border border-foreground/20 px-5 py-3 hover:bg-foreground/5 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-foreground/30 transition"
+            >
+              <ArrowUpRight className="w-5 h-5" />
+              <span className="text-base md:text-lg">Visit issuetopr.dev</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+


### PR DESCRIPTION
This PR adds a new section to the homepage that highlights our product "Issue to PR" and places it before the existing AI Breakfast section, per the request.

What’s included:
- New component: components/IssueToPR.tsx
  - Brief description of the product: an automated way to generate code for an issue and create PRs.
  - Prominent link to https://issuetopr.dev with an external-link icon and accessible labels.
- Updated app/page.tsx to insert <IssueToPR /> between <Intro /> and <Community />.

Styling/UX:
- Matches the visual style of adjacent sections (border top, spacing, typography).
- Accessible link with focus states consistent with existing components.

Quality:
- Ran `npm ci` and `npm run lint` (Next.js ESLint). No warnings or errors.

If you’d like any copy tweaks or a different CTA style (e.g., using the shared Button component), I can update quickly.

Closes #34