### PR TITLE
Fix: Prevent hero text from overlapping logo on short screens

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,6 +1,6 @@
 export default function Hero() {
   return (
-    <section className="relative min-h-[90dvh] grid place-items-center px-4">
+    <section className="relative min-h-[90dvh] grid place-items-center px-4 pt-28 md:pt-32 pb-8">
       <div className="absolute w-full  top-16 md:left-8 md:top-16 text-2xl md:text-3xl text-center">
         <p className="text-2xl md:text-3xl">Young & AI</p>
       </div>
@@ -12,3 +12,4 @@ export default function Hero() {
     </section>
   )
 }
+


### PR DESCRIPTION
Problem
On very short viewports, the hero heading ("WE BUILD AI") could overlap the "Young & AI" logo because the logo is absolutely positioned and the heading is vertically centered in the section.

Solution
- Added responsive top padding to the Hero section to reserve space for the absolutely positioned logo:
  - pt-28 on small screens, md:pt-32 on medium and up
- Kept the section's min height as min-h-[90dvh] so the hero can expand when content requires it (treating 90dvh as a minimum, not a fixed height).
- Added a small bottom padding for balance.

Result
The heading is always placed below the logo, preventing overlap even on short screens, while preserving the existing layout and responsiveness.

QA
- Resize the viewport to short heights (mobile landscape or small desktop windows): the logo remains visible at the top and the heading sits clearly below it without overlapping.
- Lint checks pass with `pnpm run lint`.

Closes #31