### PR TITLE
Remove left margin from hero logo

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,7 +1,7 @@
 export default function Hero() {
   return (
     <section className="relative min-h-[90dvh] grid place-items-center px-4 pt-28 md:pt-32 pb-8">
-      <div className="absolute w-full  top-16 md:left-8 md:top-16 text-2xl md:text-3xl text-center">
+      <div className="absolute w-full  top-16 md:top-16 text-2xl md:text-3xl text-center">
         <p className="text-2xl md:text-3xl">Young & AI</p>
       </div>
       <h1 className="font-extrabold tracking-[-0.02em] leading-[0.82] text-center text-[clamp(2.5rem,20vmin,12rem)]">


### PR DESCRIPTION
Summary
- Removed md:left-8 from the absolute logo container in components/Hero.tsx to eliminate the unintended left margin/padding on medium+ viewports.
- Kept the element full-width with text-center so the "Young & AI" logo remains centered at the top without extra horizontal offset.

Why
The hero logo appeared shifted to the right due to md:left-8. Removing it aligns the logo correctly with no extra left margin.

Verification
- Ran pnpm install and pnpm run lint; ESLint passed with no warnings/errors.
- Visual expectation: The "Young & AI" text at the top of the hero is centered with no left offset on all breakpoints.

Scope
This change is small and localized to the hero component; no other components or styles affected.

Closes #37