### PR TITLE
Jobs detail: add top padding to combined meta card content on mobile

### DIFF
--- a/app/jobs/[id]/page.tsx
+++ b/app/jobs/[id]/page.tsx
@@ -155,7 +155,7 @@ export default function JobDetailPage({ params }: { params: { id: string } }) {
           {/* Meta details combined into a single card */}
           {hasMeta && (
             <Card className="mt-6">
-              <CardContent className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-8 gap-y-4">
+              <CardContent className="pt-4 sm:pt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-8 gap-y-4">
                 {job.location && (
                   <div>
                     <div className="text-xs uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
Summary
- Addressed review feedback on PR #54: The combined meta card on the job detail page had no top padding on mobile, causing content to sit flush against the card border.

What changed
- app/jobs/[id]/page.tsx: Added pt-4 sm:pt-6 to the CardContent that renders the combined meta details card. This overrides the default pt-0 from the shared CardContent component, providing appropriate spacing at the top of the card on mobile (and a bit more on larger screens).

Why
- Reviewer noted that the top margin on mobile was too small and requested more space between the content and the top of the card. The shared CardContent uses `p-6 pt-0` by default; since this card has no header, the top padding needed to be restored locally.

Scope
- Minimal, targeted change. No layout or structural refactors beyond the requested spacing fix.

Verification
- Linted the repository (pnpm run lint): no warnings or errors.

Notes
- No changes to the original intent or design of the combined meta card, just the spacing fix requested in review.

Closes #49