### PR TITLE
Restructure homepage as AI studio + add services & products pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,86 @@
 import Link from "next/link"
-import { ArrowUpRight, ArrowRight } from "lucide-react"
+import {
+  ArrowUpRight,
+  ArrowRight,
+  MessageSquare,
+  GraduationCap,
+  Zap,
+} from "lucide-react"
 import BookingCTA from "@/components/BookingCTA"
 import { NEXT_PUBLIC_CALENDLY_LINK } from "@/lib/env"
+
+const services = [
+  {
+    title: "1-Day App Builds",
+    description:
+      "Go from idea to working AI prototype in a single day. Deployed, functional, and ready to test with real users.",
+    icon: Zap,
+    href: "/services/1-day-app",
+  },
+  {
+    title: "AI Consulting",
+    description:
+      "Strategy and implementation guidance for teams adopting AI. We assess your workflows, identify high-impact opportunities, and build a practical roadmap.",
+    icon: MessageSquare,
+    href: "/services/consulting",
+  },
+  {
+    title: "AI Training & Workshops",
+    description:
+      "Hands-on sessions that get your team building with AI tools — from prompt engineering to deploying production agents.",
+    icon: GraduationCap,
+    href: "/services/training",
+  },
+]
+
+const products = [
+  {
+    name: "Issue to PR",
+    tagline: "Autonomous coding agent",
+    description:
+      "Turns GitHub issues into ready-to-review pull requests. Engineering teams cut issue-to-merge time by 96%.",
+    url: "https://issuetopr.dev",
+  },
+  {
+    name: "Refolk",
+    tagline: "AI customer personas",
+    description:
+      "Synthesizes real customer data into living personas you can interview, debate with, and pressure-test product ideas against.",
+    url: "https://refolk.ai",
+  },
+  {
+    name: "Agent Form Filler",
+    tagline: "AI-powered form automation",
+    description:
+      "Fills out long government applications, insurance forms, and compliance paperwork using voice or text input. Cuts completion from 45 minutes to under 5.",
+  },
+  {
+    name: "File Renamer",
+    tagline: "Vision AI desktop tool",
+    description:
+      "Uses GPT-4 Vision to look at images and documents, then renames them descriptively. Turns folders of IMG_4382.jpg into a searchable archive.",
+  },
+  {
+    name: "AI Breakfast",
+    tagline: "Community",
+    description:
+      "Weekly Shanghai meetup for founders, engineers, and operators working with AI. Practical, open, and focused on shipping.",
+    url: "https://ai-breakfast.youngandai.com",
+  },
+]
 
 export default function Home() {
   return (
     <div className="max-w-3xl mx-auto px-6">
       {/* Hero */}
       <section className="pt-24 pb-24">
-        <h1 className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
-          We design, build and implement{" "}
-          <span className="text-primary">AI products and solutions</span>{" "}
-          for small and large enterprises alike.
+        <h1 className="text-5xl md:text-7xl font-bold leading-tight tracking-tight">
+          We Build <span className="text-primary">AI</span>
         </h1>
+        <p className="mt-6 text-xl md:text-2xl text-foreground/60 leading-relaxed max-w-2xl">
+          Young &amp; AI is an AI studio that builds products, offers consulting,
+          and runs training for teams ready to ship with AI.
+        </p>
         <div className="mt-10 flex flex-wrap items-center gap-6">
           <a
             href={NEXT_PUBLIC_CALENDLY_LINK}
@@ -22,129 +90,159 @@ export default function Home() {
           >
             Book a discovery call
           </a>
-          <a
-            href="mailto:contact@youngandai.com"
+          <Link
+            href="/services"
             className="text-xl text-foreground/50 underline underline-offset-4 decoration-foreground/20 hover:text-foreground/70 hover:decoration-foreground/40 transition-colors"
           >
-            or email us
-          </a>
+            View services
+          </Link>
         </div>
       </section>
 
-      {/* Portfolio */}
-      <section id="portfolio" className="pb-24">
+      {/* Services */}
+      <section id="services" className="pb-24">
         <h2 className="text-xl uppercase tracking-widest text-primary/70 mb-10">
-          What we&apos;ve built
+          Services
         </h2>
-
-        <div className="divide-y divide-primary/15">
-          <Link
-            href="https://issuetopr.dev"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group block py-8 first:pt-0"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="text-2xl md:text-3xl font-bold group-hover:text-foreground/70 transition-colors">
-                  Issue to PR
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {services.map((service) => {
+            const Icon = service.icon
+            return (
+              <Link
+                key={service.title}
+                href={service.href}
+                className="group rounded-2xl border border-primary/10 p-6 hover:border-primary/25 transition-colors"
+              >
+                <Icon className="w-6 h-6 text-primary mb-4" />
+                <h3 className="text-lg font-bold group-hover:text-primary transition-colors">
+                  {service.title}
                 </h3>
-                <p className="mt-1 text-base text-primary/60 font-medium">
-                  Autonomous coding agent
+                <p className="mt-2 text-sm text-foreground/60 leading-relaxed">
+                  {service.description}
                 </p>
-                <p className="mt-3 text-xl text-foreground/60 leading-relaxed">
-                  Turns GitHub issues into ready-to-review pull requests.
-                  Engineering teams cut issue-to-merge time by 96% — the agent
-                  reads the issue, analyzes the codebase, writes the code, and
-                  opens a PR.
-                </p>
-              </div>
-              <ArrowUpRight className="w-6 h-6 mt-2 shrink-0 text-foreground/30 group-hover:text-primary transition-colors" />
-            </div>
-          </Link>
-
-          <Link
-            href="https://refolk.ai"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group block py-8"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="text-2xl md:text-3xl font-bold group-hover:text-foreground/70 transition-colors">
-                  Refolk
-                </h3>
-                <p className="mt-1 text-base text-primary/60 font-medium">
-                  AI customer personas
-                </p>
-                <p className="mt-3 text-xl text-foreground/60 leading-relaxed">
-                  Synthesizes real customer data into living personas you can
-                  interview, debate with, and pressure-test product ideas
-                  against. Replaces guesswork with data-driven user research.
-                </p>
-              </div>
-              <ArrowUpRight className="w-6 h-6 mt-2 shrink-0 text-foreground/30 group-hover:text-primary transition-colors" />
-            </div>
-          </Link>
-
-          <div className="py-8">
-            <h3 className="text-2xl md:text-3xl font-bold">
-              Agent Form Filler
-            </h3>
-            <p className="mt-1 text-base text-primary/60 font-medium">
-              AI-powered form automation
-            </p>
-            <p className="mt-3 text-xl text-foreground/60 leading-relaxed">
-              Fills out long government applications, insurance forms, and
-              compliance paperwork using voice or text input. Cuts form
-              completion from 45 minutes to under 5.
-            </p>
-          </div>
-
-          <div className="py-8">
-            <h3 className="text-2xl md:text-3xl font-bold">File Renamer</h3>
-            <p className="mt-1 text-base text-primary/60 font-medium">
-              Vision AI desktop tool
-            </p>
-            <p className="mt-3 text-xl text-foreground/60 leading-relaxed">
-              Uses GPT-4 Vision to look at images and documents, then renames
-              them descriptively. Turns folders of IMG_4382.jpg into a
-              searchable, organized archive.
-            </p>
-          </div>
-
-          <Link
-            href="https://ai-breakfast.youngandai.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group block py-8"
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="text-2xl md:text-3xl font-bold group-hover:text-foreground/70 transition-colors">
-                  AI Breakfast
-                </h3>
-                <p className="mt-1 text-base text-primary/60 font-medium">
-                  Community
-                </p>
-                <p className="mt-3 text-xl text-foreground/60 leading-relaxed">
-                  Weekly Shanghai meetup for founders, engineers, and operators
-                  working with AI. Practical, open, and focused on shipping.
-                </p>
-              </div>
-              <ArrowUpRight className="w-6 h-6 mt-2 shrink-0 text-foreground/30 group-hover:text-primary transition-colors" />
-            </div>
-          </Link>
+                <span className="mt-4 inline-flex items-center gap-1 text-sm text-primary/70 group-hover:text-primary transition-colors">
+                  Learn more <ArrowRight className="w-3.5 h-3.5" />
+                </span>
+              </Link>
+            )
+          })}
         </div>
+      </section>
 
-        <div className="mt-10">
+      {/* Products */}
+      <section id="products" className="pb-24">
+        <h2 className="text-xl uppercase tracking-widest text-primary/70 mb-10">
+          Products &amp; Projects
+        </h2>
+        <div className="divide-y divide-primary/15">
+          {products.map((product) => {
+            const inner = (
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-2xl md:text-3xl font-bold group-hover:text-foreground/70 transition-colors">
+                    {product.name}
+                  </h3>
+                  <p className="mt-1 text-base text-primary/60 font-medium">
+                    {product.tagline}
+                  </p>
+                  <p className="mt-3 text-lg text-foreground/60 leading-relaxed">
+                    {product.description}
+                  </p>
+                </div>
+                {product.url && (
+                  <ArrowUpRight className="w-6 h-6 mt-2 shrink-0 text-foreground/30 group-hover:text-primary transition-colors" />
+                )}
+              </div>
+            )
+
+            return product.url ? (
+              <Link
+                key={product.name}
+                href={product.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group block py-8 first:pt-0"
+              >
+                {inner}
+              </Link>
+            ) : (
+              <div key={product.name} className="py-8 first:pt-0">
+                {inner}
+              </div>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* About / Story */}
+      <section id="about" className="pb-24">
+        <h2 className="text-xl uppercase tracking-widest text-primary/70 mb-10">
+          About
+        </h2>
+        <div className="space-y-6 text-foreground/80 text-xl leading-relaxed">
+          <p>
+            Young &amp; AI was founded by{" "}
+            <span className="font-semibold text-foreground">
+              Ching Jui Young
+            </span>{" "}
+            in Shanghai. With a background spanning enterprise software,
+            automation, and data platforms, Ching has helped companies of every
+            size adopt AI — from early prototypes to production systems running
+            at scale.
+          </p>
+          <p>
+            We also run{" "}
+            <a
+              href="https://ai-breakfast.youngandai.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline underline-offset-4 decoration-primary/30 hover:decoration-primary/60 transition-colors"
+            >
+              AI Breakfast
+            </a>
+            , a weekly Shanghai meetup where founders, engineers, and operators
+            trade notes on what&apos;s working in AI.
+          </p>
+        </div>
+        <div className="mt-8">
           <Link
-            href="/services"
+            href="/about"
             className="inline-flex items-center gap-2 text-lg text-primary/70 hover:text-primary font-medium transition-colors"
           >
-            See how we can build yours
+            Read more about us
             <ArrowRight className="w-5 h-5" />
           </Link>
+        </div>
+      </section>
+
+      {/* Blog / Newsletter */}
+      <section id="blog" className="pb-24">
+        <h2 className="text-xl uppercase tracking-widest text-primary/70 mb-10">
+          Blog &amp; Newsletter
+        </h2>
+        <div className="rounded-2xl border border-primary/10 p-8">
+          <h3 className="text-2xl font-bold">Stay in the loop</h3>
+          <p className="mt-3 text-lg text-foreground/60 leading-relaxed">
+            We write about AI engineering, product building, and lessons from
+            running an AI studio. Follow along for practical insights.
+          </p>
+          <div className="mt-6 flex flex-wrap items-center gap-4">
+            <a
+              href="https://ai-breakfast.youngandai.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-primary/15 px-5 py-2.5 text-sm font-bold text-foreground hover:bg-primary/5 transition-colors"
+            >
+              Visit AI Breakfast
+              <ArrowUpRight className="w-4 h-4" />
+            </a>
+            <a
+              href="mailto:contact@youngandai.com"
+              className="text-sm text-foreground/50 underline underline-offset-4 decoration-foreground/20 hover:text-foreground/70 transition-colors"
+            >
+              Subscribe via email
+            </a>
+          </div>
         </div>
       </section>
 

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,0 +1,184 @@
+import { Metadata } from "next"
+import Link from "next/link"
+import { ArrowUpRight, ArrowRight } from "lucide-react"
+import BookingCTA from "@/components/BookingCTA"
+
+export const metadata: Metadata = {
+  title: "Products | Young & AI",
+  description:
+    "AI products built by Young & AI — from autonomous coding agents to AI customer personas.",
+}
+
+const featured = [
+  {
+    name: "Issue to PR",
+    tagline: "Autonomous coding agent",
+    description:
+      "Turns GitHub issues into ready-to-review pull requests. The agent reads the issue, analyzes the codebase, writes the code, and opens a PR — cutting issue-to-merge time by 96%.",
+    url: "https://issuetopr.dev",
+    builtIn: "2 weeks",
+  },
+  {
+    name: "Refolk",
+    tagline: "AI customer personas",
+    description:
+      "Synthesizes real customer data into living personas you can interview, debate with, and pressure-test product ideas against. Replaces guesswork with data-driven user research.",
+    url: "https://refolk.ai",
+    builtIn: "3 weeks",
+  },
+]
+
+const projects = [
+  {
+    name: "Agent Form Filler",
+    tagline: "AI-powered form automation",
+    description:
+      "Fills out long government applications, insurance forms, and compliance paperwork using voice or text input. Cuts form completion from 45 minutes to under 5.",
+    builtIn: "1 week",
+  },
+  {
+    name: "File Renamer",
+    tagline: "Vision AI desktop tool",
+    description:
+      "Uses GPT-4 Vision to look at images and documents, then renames them descriptively. Turns folders of IMG_4382.jpg into a searchable, organized archive.",
+    builtIn: "2 days",
+  },
+  {
+    name: "AI Breakfast",
+    tagline: "Community",
+    description:
+      "Weekly Shanghai meetup for founders, engineers, and operators working with AI. Practical, open, and focused on shipping.",
+    url: "https://ai-breakfast.youngandai.com",
+  },
+]
+
+export default function ProductsPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6">
+      {/* Hero */}
+      <section className="pt-24 pb-24">
+        <h1 className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
+          What we&apos;ve <span className="text-primary">built</span>
+        </h1>
+        <p className="mt-6 text-xl text-foreground/60 leading-relaxed">
+          AI products and tools we&apos;ve shipped — from autonomous coding
+          agents to AI-powered research tools. Every project started as a
+          conversation.
+        </p>
+      </section>
+
+      {/* Featured Products */}
+      <section className="pb-24">
+        <h2 className="text-xl uppercase tracking-widest text-primary/70 mb-10">
+          Featured
+        </h2>
+        <div className="space-y-6">
+          {featured.map((product) => (
+            <a
+              key={product.name}
+              href={product.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block rounded-2xl border border-primary/10 p-8 hover:border-primary/25 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-2xl md:text-3xl font-bold group-hover:text-primary transition-colors">
+                    {product.name}
+                  </h2>
+                  <p className="mt-1 text-base text-primary/60 font-medium">
+                    {product.tagline}
+                  </p>
+                </div>
+                <ArrowUpRight className="w-6 h-6 mt-2 shrink-0 text-foreground/30 group-hover:text-primary transition-colors" />
+              </div>
+              <p className="mt-4 text-lg text-foreground/60 leading-relaxed">
+                {product.description}
+              </p>
+              <div className="mt-4 flex items-center gap-4">
+                <span className="text-sm text-foreground/30">
+                  Built in {product.builtIn}
+                </span>
+                <span className="text-sm text-primary/70 group-hover:text-primary transition-colors">
+                  {product.url.replace("https://", "")}
+                </span>
+              </div>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      {/* More Projects */}
+      <section className="pb-24">
+        <h2 className="text-xl uppercase tracking-widest text-primary/70 mb-10">
+          More projects
+        </h2>
+        <div className="divide-y divide-primary/15">
+          {projects.map((project) => {
+            const inner = (
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-2xl md:text-3xl font-bold group-hover:text-foreground/70 transition-colors">
+                    {project.name}
+                  </h3>
+                  <p className="mt-1 text-base text-primary/60 font-medium">
+                    {project.tagline}
+                  </p>
+                  <p className="mt-3 text-lg text-foreground/60 leading-relaxed">
+                    {project.description}
+                  </p>
+                  {project.builtIn && (
+                    <span className="mt-2 inline-block text-sm text-foreground/30">
+                      Built in {project.builtIn}
+                    </span>
+                  )}
+                </div>
+                {project.url && (
+                  <ArrowUpRight className="w-6 h-6 mt-2 shrink-0 text-foreground/30 group-hover:text-primary transition-colors" />
+                )}
+              </div>
+            )
+
+            return project.url ? (
+              <a
+                key={project.name}
+                href={project.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group block py-8 first:pt-0"
+              >
+                {inner}
+              </a>
+            ) : (
+              <div key={project.name} className="py-8 first:pt-0">
+                {inner}
+              </div>
+            )
+          })}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="pb-24">
+        <div className="rounded-2xl border border-primary/10 p-8 text-center">
+          <h2 className="text-2xl font-bold">Want us to build something?</h2>
+          <p className="mt-3 text-lg text-foreground/60 max-w-md mx-auto">
+            Every product above started as a conversation. Tell us what you need
+            and we&apos;ll scope it out.
+          </p>
+          <div className="mt-6">
+            <Link
+              href="/services"
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-lg font-bold text-white hover:opacity-90 transition-opacity"
+            >
+              View our services
+              <ArrowRight className="w-5 h-5" />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <BookingCTA />
+    </div>
+  )
+}

--- a/app/services/1-day-app/page.tsx
+++ b/app/services/1-day-app/page.tsx
@@ -1,0 +1,226 @@
+import { Metadata } from "next"
+import Link from "next/link"
+import { ArrowLeft, ArrowRight, Check } from "lucide-react"
+import {
+  NEXT_PUBLIC_STRIPE_1DAY_LINK,
+  NEXT_PUBLIC_CALENDLY_LINK,
+} from "@/lib/env"
+
+export const metadata: Metadata = {
+  title: "1-Day App Builds | Young & AI",
+  description:
+    "Go from idea to working AI prototype in a single day. Deployed, functional, and ready to test with real users. Starting at $950.",
+}
+
+const howItWorks = [
+  {
+    step: "1",
+    title: "Brief us",
+    description:
+      "Tell us what you want to build. We'll scope it to what's achievable in a day and confirm the approach.",
+  },
+  {
+    step: "2",
+    title: "We build",
+    description:
+      "Our team builds your AI-powered app end-to-end: UI, backend, AI integration, and deployment.",
+  },
+  {
+    step: "3",
+    title: "You ship",
+    description:
+      "By end of day you have a working app on a live URL, source code handoff, and a 30-minute walkthrough.",
+  },
+]
+
+const whatYouGet = [
+  "Working AI-powered prototype",
+  "Deployed to a live URL",
+  "Full source code handoff",
+  "30-minute walkthrough call",
+  "Built with production-grade tools (Next.js, TypeScript, etc.)",
+]
+
+const examples = [
+  "Internal tool that summarizes support tickets",
+  "AI chatbot trained on your documentation",
+  "Automated report generator from raw data",
+  "Customer feedback analyzer with sentiment scoring",
+  "Document comparison and review tool",
+]
+
+const whoItsFor = [
+  "Founders validating a product idea before committing",
+  "Teams needing a quick internal tool",
+  "Companies exploring AI before a larger engagement",
+  "Anyone with an idea they want to see working today",
+]
+
+export default function OneDayAppPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6">
+      <div className="pt-8">
+        <Link
+          href="/services"
+          className="inline-flex items-center gap-1.5 text-sm text-foreground/40 hover:text-foreground/60 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          All services
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <section className="pt-12 pb-24">
+        <h1 className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
+          1-Day App{" "}
+          <span className="text-primary">Builds</span>
+        </h1>
+        <p className="mt-6 text-xl text-foreground/60 leading-relaxed max-w-2xl">
+          Go from idea to working AI prototype in a single day. Not a mockup —
+          a deployed, functional app you can test with real users.
+        </p>
+        <div className="mt-10 flex flex-wrap items-center gap-6">
+          <a
+            href={NEXT_PUBLIC_STRIPE_1DAY_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded-lg bg-primary px-8 py-4 text-xl font-bold text-white hover:opacity-90 transition-opacity"
+          >
+            Get started — $950
+          </a>
+          <a
+            href={NEXT_PUBLIC_CALENDLY_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xl text-foreground/50 underline underline-offset-4 decoration-foreground/20 hover:text-foreground/70 hover:decoration-foreground/40 transition-colors"
+          >
+            or book a call first
+          </a>
+        </div>
+      </section>
+
+      {/* How It Works */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">How it works</h2>
+        <div className="space-y-8">
+          {howItWorks.map((item) => (
+            <div key={item.step} className="flex gap-6">
+              <span className="shrink-0 w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-lg font-bold text-primary">
+                {item.step}
+              </span>
+              <div>
+                <h3 className="text-xl font-bold">{item.title}</h3>
+                <p className="mt-1 text-lg text-foreground/60 leading-relaxed">
+                  {item.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* What You Get */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">What you get</h2>
+        <ul className="space-y-4">
+          {whatYouGet.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-3 text-lg text-foreground/70"
+            >
+              <Check className="w-5 h-5 text-primary shrink-0 mt-1" />
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Example Builds */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-4">Example builds</h2>
+        <p className="text-lg text-foreground/50 mb-6">
+          Things we&apos;ve built (or could build) in a day:
+        </p>
+        <ul className="space-y-3">
+          {examples.map((example) => (
+            <li
+              key={example}
+              className="flex items-start gap-3 text-lg text-foreground/60"
+            >
+              <ArrowRight className="w-4 h-4 text-primary/50 shrink-0 mt-1.5" />
+              {example}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Who It's For */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">Who it&apos;s for</h2>
+        <ul className="space-y-4">
+          {whoItsFor.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-3 text-lg text-foreground/70"
+            >
+              <Check className="w-5 h-5 text-primary shrink-0 mt-1" />
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Pricing */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-4">Pricing</h2>
+        <div className="rounded-2xl border border-primary/10 p-8">
+          <div className="flex items-baseline gap-3">
+            <span className="text-4xl font-bold">$950</span>
+            <span className="text-lg text-foreground/40">per build</span>
+          </div>
+          <p className="mt-4 text-lg text-foreground/60 leading-relaxed">
+            One flat price. Includes everything: design, development, deployment,
+            source code, and walkthrough. No hidden fees.
+          </p>
+          <p className="mt-4 text-base text-foreground/40">
+            Need something bigger? Check out our{" "}
+            <Link
+              href="/services"
+              className="text-primary underline underline-offset-4 decoration-primary/30 hover:decoration-primary/60 transition-colors"
+            >
+              1-week and 1-month build packages
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="pb-24 text-center">
+        <h2 className="text-3xl font-bold">Ready to build?</h2>
+        <p className="mt-4 text-lg text-foreground/50 max-w-md mx-auto">
+          Pay now and we&apos;ll reach out to scope your project. Or book a call
+          to discuss first.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-6">
+          <a
+            href={NEXT_PUBLIC_STRIPE_1DAY_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded-lg bg-primary px-8 py-4 text-xl font-bold text-white hover:opacity-90 transition-opacity"
+          >
+            Get started — $950
+          </a>
+          <a
+            href={NEXT_PUBLIC_CALENDLY_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xl text-foreground/50 underline underline-offset-4 decoration-foreground/20 hover:text-foreground/70 hover:decoration-foreground/40 transition-colors"
+          >
+            Book a free call
+          </a>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/services/consulting/page.tsx
+++ b/app/services/consulting/page.tsx
@@ -1,0 +1,147 @@
+import { Metadata } from "next"
+import Link from "next/link"
+import { ArrowLeft, Check } from "lucide-react"
+import { NEXT_PUBLIC_CALENDLY_LINK } from "@/lib/env"
+
+export const metadata: Metadata = {
+  title: "AI Consulting | Young & AI",
+  description:
+    "Strategic AI consulting for teams adopting AI. Workflow audits, architecture guidance, and hands-on implementation support.",
+}
+
+const whatWeDeliver = [
+  {
+    title: "Workflow Audit",
+    description:
+      "We map your current processes end-to-end, identifying where AI can save time, reduce errors, or unlock new capabilities.",
+  },
+  {
+    title: "Tool & Architecture Selection",
+    description:
+      "We recommend the right models, frameworks, and infrastructure for your use case — no vendor lock-in, no unnecessary complexity.",
+  },
+  {
+    title: "Implementation Support",
+    description:
+      "We work alongside your engineering team to build, test, and deploy. Not just a strategy deck — working software.",
+  },
+  {
+    title: "Ongoing Advisory",
+    description:
+      "AI moves fast. We stay on as advisors to help you adapt, evaluate new tools, and scale what's working.",
+  },
+]
+
+const whoItsFor = [
+  "Engineering teams evaluating AI tools and workflows",
+  "Founders figuring out where AI fits in their product",
+  "Operations teams looking to automate repetitive processes",
+  "Companies with AI projects that stalled or underperformed",
+]
+
+export default function ConsultingPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6">
+      <div className="pt-8">
+        <Link
+          href="/services"
+          className="inline-flex items-center gap-1.5 text-sm text-foreground/40 hover:text-foreground/60 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          All services
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <section className="pt-12 pb-24">
+        <h1 className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
+          AI <span className="text-primary">Consulting</span>
+        </h1>
+        <p className="mt-6 text-xl text-foreground/60 leading-relaxed max-w-2xl">
+          We help teams adopt AI with clear strategy and hands-on
+          implementation. No buzzwords — just practical guidance that gets you
+          from idea to production.
+        </p>
+        <div className="mt-10">
+          <a
+            href={NEXT_PUBLIC_CALENDLY_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded-lg bg-primary px-8 py-4 text-xl font-bold text-white hover:opacity-90 transition-opacity"
+          >
+            Book a free consultation
+          </a>
+          <p className="mt-3 text-sm text-foreground/30">
+            30 minutes &middot; No commitment
+          </p>
+        </div>
+      </section>
+
+      {/* What We Deliver */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">What we deliver</h2>
+        <div className="space-y-8">
+          {whatWeDeliver.map((item) => (
+            <div key={item.title}>
+              <h3 className="text-xl font-bold">{item.title}</h3>
+              <p className="mt-2 text-lg text-foreground/60 leading-relaxed">
+                {item.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Who It's For */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">Who it&apos;s for</h2>
+        <ul className="space-y-4">
+          {whoItsFor.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-3 text-lg text-foreground/70"
+            >
+              <Check className="w-5 h-5 text-primary shrink-0 mt-1" />
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Pricing */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-4">Pricing</h2>
+        <div className="rounded-2xl border border-primary/10 p-8">
+          <p className="text-lg text-foreground/60 leading-relaxed">
+            Consulting engagements are scoped per project. Most start with a
+            2-week assessment, then move to ongoing advisory or implementation
+            support as needed.
+          </p>
+          <p className="mt-4 text-lg text-foreground/60 leading-relaxed">
+            <span className="font-semibold text-foreground">
+              Starting at $2,500
+            </span>{" "}
+            for an initial assessment. Custom pricing for ongoing engagements.
+          </p>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="pb-24 text-center">
+        <h2 className="text-3xl font-bold">Let&apos;s talk</h2>
+        <p className="mt-4 text-lg text-foreground/50 max-w-md mx-auto">
+          Book a free call and we&apos;ll discuss your goals, assess the
+          opportunity, and recommend next steps.
+        </p>
+        <a
+          href={NEXT_PUBLIC_CALENDLY_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-6 inline-block rounded-lg bg-primary px-8 py-4 text-xl font-bold text-white hover:opacity-90 transition-opacity"
+        >
+          Book a free consultation
+        </a>
+      </section>
+    </div>
+  )
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,5 +1,14 @@
 import { Metadata } from "next"
-import { Check, ArrowRight, Zap, Rocket, Building2 } from "lucide-react"
+import Link from "next/link"
+import {
+  ArrowRight,
+  MessageSquare,
+  GraduationCap,
+  Zap,
+  Check,
+  Rocket,
+  Building2,
+} from "lucide-react"
 import {
   NEXT_PUBLIC_STRIPE_1DAY_LINK,
   NEXT_PUBLIC_STRIPE_1WEEK_LINK,
@@ -8,45 +17,54 @@ import {
 } from "@/lib/env"
 
 export const metadata: Metadata = {
-  title: "Services",
+  title: "Services | Young & AI",
   description:
-    "See what we've built, then let us build yours — from a 1-day prototype to a full product.",
+    "AI consulting, training, and rapid product builds. See how Young & AI can help your team ship with AI.",
 }
 
-const showcase = [
+const services = [
   {
-    name: "Issue to PR",
-    oneLiner: "Turns GitHub issues into ready-to-review pull requests",
-    businessValue:
-      "Engineering teams spend hours writing boilerplate code for well-defined tickets. This agent reads the issue, analyzes the repo, writes the code, and opens a PR — cutting issue-to-merge time by 96%.",
-    builtIn: "2 weeks",
-    url: "https://issuetopr.dev",
+    title: "1-Day App Builds",
+    description:
+      "Go from idea to working AI prototype in a single day. Deployed, functional, and ready to test with real users.",
+    icon: Zap,
+    href: "/services/1-day-app",
+    features: [
+      "Working prototype in 24 hours",
+      "Deployed to a live URL",
+      "Source code handoff",
+      "30-min walkthrough call",
+    ],
   },
   {
-    name: "Refolk",
-    oneLiner: "AI-generated customer personas from real data",
-    businessValue:
-      "Product teams make decisions based on guesswork about their users. Refolk synthesizes real customer data into living personas you can interview, debate with, and pressure-test ideas against.",
-    builtIn: "3 weeks",
-    url: "https://refolk.ai",
+    title: "AI Consulting",
+    description:
+      "We assess your workflows, identify high-impact AI opportunities, and build a practical roadmap for adoption. From strategy to implementation.",
+    icon: MessageSquare,
+    href: "/services/consulting",
+    features: [
+      "Workflow audit & opportunity mapping",
+      "Tool selection & architecture",
+      "Implementation support",
+      "Ongoing advisory",
+    ],
   },
   {
-    name: "Agent Form Filler",
-    oneLiner: "Fills out long, complicated forms using AI",
-    businessValue:
-      "Government applications, insurance forms, compliance paperwork — people waste hours on data entry. This agent takes voice or text input and fills multi-step forms automatically, reducing completion time from 45 minutes to under 5.",
-    builtIn: "1 week",
-  },
-  {
-    name: "File Renamer",
-    oneLiner: "Renames files based on what's actually in them",
-    businessValue:
-      "Teams drown in folders of IMG_4382.jpg and scan_final_v2.pdf. This desktop app uses GPT-4 Vision to look at each image or document and rename it descriptively — turning chaos into a searchable archive.",
-    builtIn: "2 days",
+    title: "AI Training & Workshops",
+    description:
+      "Hands-on sessions that get your team building with AI tools. From prompt engineering to deploying production agents.",
+    icon: GraduationCap,
+    href: "/services/training",
+    features: [
+      "Custom curriculum for your team",
+      "Hands-on exercises with real tools",
+      "From beginner to advanced",
+      "Follow-up support included",
+    ],
   },
 ]
 
-const tiers = [
+const buildTiers = [
   {
     name: "1-Day Build",
     price: "$950",
@@ -59,7 +77,7 @@ const tiers = [
       "Source code handoff",
       "30-min walkthrough",
     ],
-    stripeEnv: "NEXT_PUBLIC_STRIPE_1DAY_LINK",
+    stripeLink: NEXT_PUBLIC_STRIPE_1DAY_LINK,
     highlight: false,
   },
   {
@@ -75,7 +93,7 @@ const tiers = [
       "Auth, UI, deployment & CI/CD",
       "Documentation & handoff",
     ],
-    stripeEnv: "NEXT_PUBLIC_STRIPE_1WEEK_LINK",
+    stripeLink: NEXT_PUBLIC_STRIPE_1WEEK_LINK,
     highlight: true,
   },
   {
@@ -91,16 +109,10 @@ const tiers = [
       "Admin dashboard & analytics",
       "2 weeks post-launch support",
     ],
-    stripeEnv: "NEXT_PUBLIC_STRIPE_1MONTH_LINK",
+    stripeLink: NEXT_PUBLIC_STRIPE_1MONTH_LINK,
     highlight: false,
   },
 ]
-
-const stripeLinks: Record<string, string> = {
-  NEXT_PUBLIC_STRIPE_1DAY_LINK,
-  NEXT_PUBLIC_STRIPE_1WEEK_LINK,
-  NEXT_PUBLIC_STRIPE_1MONTH_LINK,
-}
 
 export default function ServicesPage() {
   return (
@@ -108,70 +120,69 @@ export default function ServicesPage() {
       {/* Hero */}
       <section className="pt-24 pb-24">
         <h1 className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
-          We built these.{" "}
-          <span className="text-primary">Let us build yours.</span>
+          How we can <span className="text-primary">help</span>
         </h1>
         <p className="mt-6 text-xl text-foreground/60 leading-relaxed">
-          Every project below started as a conversation. Browse what
-          we&apos;ve shipped, then tell us what you need automated,
-          simplified, or built from scratch.
+          Whether you need strategic guidance, team upskilling, or a working
+          product built fast — we have a service for that.
         </p>
       </section>
 
-      {/* Showcase */}
+      {/* Service Cards */}
       <section className="pb-24">
-        <div className="divide-y divide-primary/15">
-          {showcase.map((project) => (
-            <div key={project.name} className="py-10 first:pt-0 last:pb-0">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <h2 className="text-2xl md:text-3xl font-bold">
-                    {project.name}
-                  </h2>
-                  <p className="mt-1 text-lg text-primary/70 font-medium">
-                    {project.oneLiner}
-                  </p>
+        <div className="space-y-6">
+          {services.map((service) => {
+            const Icon = service.icon
+            return (
+              <Link
+                key={service.title}
+                href={service.href}
+                className="group block rounded-2xl border border-primary/10 p-8 hover:border-primary/25 transition-colors"
+              >
+                <div className="flex items-start gap-4">
+                  <Icon className="w-7 h-7 text-primary shrink-0 mt-1" />
+                  <div className="flex-1">
+                    <h2 className="text-2xl font-bold group-hover:text-primary transition-colors">
+                      {service.title}
+                    </h2>
+                    <p className="mt-2 text-lg text-foreground/60 leading-relaxed">
+                      {service.description}
+                    </p>
+                    <ul className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      {service.features.map((feature) => (
+                        <li
+                          key={feature}
+                          className="flex items-center gap-2 text-sm text-foreground/50"
+                        >
+                          <Check className="w-4 h-4 text-primary/60 shrink-0" />
+                          {feature}
+                        </li>
+                      ))}
+                    </ul>
+                    <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-primary/70 group-hover:text-primary transition-colors">
+                      Learn more <ArrowRight className="w-3.5 h-3.5" />
+                    </span>
+                  </div>
                 </div>
-                <span className="shrink-0 text-sm text-foreground/30 mt-2">
-                  Built in {project.builtIn}
-                </span>
-              </div>
-              <p className="mt-4 text-lg text-foreground/60 leading-relaxed">
-                {project.businessValue}
-              </p>
-              {project.url && (
-                <a
-                  href={project.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-3 inline-flex items-center gap-1.5 text-sm text-primary/70 hover:text-primary transition-colors"
-                >
-                  Visit {project.url.replace("https://", "")}
-                  <ArrowRight className="w-3.5 h-3.5" />
-                </a>
-              )}
-            </div>
-          ))}
+              </Link>
+            )
+          })}
         </div>
       </section>
 
-      {/* Transition */}
-      <section className="pb-16">
+      {/* Build Packages */}
+      <section className="pb-24">
         <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
-          Have something in mind?
+          Build packages
         </h2>
         <p className="mt-4 text-xl text-foreground/60 leading-relaxed">
           Pick a timeline. You get a working product deployed to production —
-          not a proposal deck. Start small with a 1-day build, or go all in.
+          not a proposal deck.
         </p>
-      </section>
 
-      {/* Tiers */}
-      <section className="pb-24">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {tiers.map((tier) => {
+        <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-6">
+          {buildTiers.map((tier) => {
             const Icon = tier.icon
-            const stripeLink = stripeLinks[tier.stripeEnv]
             return (
               <div
                 key={tier.name}
@@ -221,7 +232,7 @@ export default function ServicesPage() {
                 </ul>
 
                 <a
-                  href={stripeLink}
+                  href={tier.stripeLink}
                   target="_blank"
                   rel="noopener noreferrer"
                   className={`mt-6 inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 text-sm font-bold transition-opacity ${

--- a/app/services/training/page.tsx
+++ b/app/services/training/page.tsx
@@ -1,0 +1,171 @@
+import { Metadata } from "next"
+import Link from "next/link"
+import { ArrowLeft, Check } from "lucide-react"
+import { NEXT_PUBLIC_CALENDLY_LINK } from "@/lib/env"
+
+export const metadata: Metadata = {
+  title: "AI Training & Workshops | Young & AI",
+  description:
+    "Hands-on AI training for teams. From prompt engineering to building production agents — custom workshops tailored to your stack.",
+}
+
+const formats = [
+  {
+    title: "Half-Day Workshop",
+    duration: "4 hours",
+    description:
+      "Focused session on a specific topic — prompt engineering, AI tools for developers, or building your first agent. Great for kickoffs.",
+    price: "From $1,500",
+  },
+  {
+    title: "Full-Day Intensive",
+    duration: "8 hours",
+    description:
+      "Deep dive with hands-on exercises. Your team builds a working AI feature by end of day using your own codebase and data.",
+    price: "From $3,000",
+  },
+  {
+    title: "Multi-Day Program",
+    duration: "2–5 days",
+    description:
+      "Comprehensive upskilling program. Covers fundamentals through advanced topics, with each day building on the last. Includes follow-up support.",
+    price: "Custom pricing",
+  },
+]
+
+const topics = [
+  "Prompt engineering & LLM fundamentals",
+  "Building AI agents with tool use",
+  "RAG (Retrieval-Augmented Generation) systems",
+  "AI-assisted coding workflows",
+  "Deploying AI to production safely",
+  "Evaluating & testing AI systems",
+]
+
+const whoItsFor = [
+  "Engineering teams adopting AI tools for the first time",
+  "Product teams wanting to understand AI capabilities",
+  "Companies running internal AI upskilling programs",
+  "Teams building AI features into existing products",
+]
+
+export default function TrainingPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6">
+      <div className="pt-8">
+        <Link
+          href="/services"
+          className="inline-flex items-center gap-1.5 text-sm text-foreground/40 hover:text-foreground/60 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          All services
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <section className="pt-12 pb-24">
+        <h1 className="text-4xl md:text-6xl font-bold leading-tight tracking-tight">
+          AI Training &amp;{" "}
+          <span className="text-primary">Workshops</span>
+        </h1>
+        <p className="mt-6 text-xl text-foreground/60 leading-relaxed max-w-2xl">
+          Hands-on sessions that get your team building with AI. Not slides and
+          theory — real tools, real exercises, real output by end of day.
+        </p>
+        <div className="mt-10">
+          <a
+            href={NEXT_PUBLIC_CALENDLY_LINK}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded-lg bg-primary px-8 py-4 text-xl font-bold text-white hover:opacity-90 transition-opacity"
+          >
+            Book a free consultation
+          </a>
+          <p className="mt-3 text-sm text-foreground/30">
+            We&apos;ll scope a program for your team
+          </p>
+        </div>
+      </section>
+
+      {/* Formats */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">Workshop formats</h2>
+        <div className="space-y-6">
+          {formats.map((format) => (
+            <div
+              key={format.title}
+              className="rounded-2xl border border-primary/10 p-8"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-xl font-bold">{format.title}</h3>
+                  <p className="mt-1 text-sm text-primary/60 font-medium">
+                    {format.duration}
+                  </p>
+                </div>
+                <span className="shrink-0 text-sm font-semibold text-foreground/50">
+                  {format.price}
+                </span>
+              </div>
+              <p className="mt-3 text-lg text-foreground/60 leading-relaxed">
+                {format.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Topics */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">Topics we cover</h2>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {topics.map((topic) => (
+            <li
+              key={topic}
+              className="flex items-start gap-3 text-lg text-foreground/70"
+            >
+              <Check className="w-5 h-5 text-primary shrink-0 mt-1" />
+              {topic}
+            </li>
+          ))}
+        </ul>
+        <p className="mt-6 text-base text-foreground/40">
+          All workshops are customized to your team&apos;s stack and goals.
+        </p>
+      </section>
+
+      {/* Who It's For */}
+      <section className="pb-24">
+        <h2 className="text-2xl font-bold mb-8">Who it&apos;s for</h2>
+        <ul className="space-y-4">
+          {whoItsFor.map((item) => (
+            <li
+              key={item}
+              className="flex items-start gap-3 text-lg text-foreground/70"
+            >
+              <Check className="w-5 h-5 text-primary shrink-0 mt-1" />
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* CTA */}
+      <section className="pb-24 text-center">
+        <h2 className="text-3xl font-bold">Ready to upskill your team?</h2>
+        <p className="mt-4 text-lg text-foreground/50 max-w-md mx-auto">
+          Book a free call and we&apos;ll design a workshop tailored to your
+          team&apos;s needs and experience level.
+        </p>
+        <a
+          href={NEXT_PUBLIC_CALENDLY_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-6 inline-block rounded-lg bg-primary px-8 py-4 text-xl font-bold text-white hover:opacity-90 transition-opacity"
+        >
+          Book a free consultation
+        </a>
+      </section>
+    </div>
+  )
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -8,16 +8,16 @@ export default function Nav() {
       </Link>
       <div className="flex items-center gap-6 text-lg md:text-xl text-foreground/60">
         <Link
-          href="/#portfolio"
-          className="hover:text-foreground transition-colors"
-        >
-          Portfolio
-        </Link>
-        <Link
           href="/services"
           className="hover:text-foreground transition-colors"
         >
           Services
+        </Link>
+        <Link
+          href="/products"
+          className="hover:text-foreground transition-colors"
+        >
+          Products
         </Link>
         <Link
           href="/about"


### PR DESCRIPTION
## Summary
- Restructured homepage with 5 sections: Hero ("We Build AI"), Services, Products, About/Story, Blog/Newsletter
- Created `/products` page with featured products (Issue to PR, Refolk) and project listings
- Created `/services` index page listing all services + build pricing tiers
- Created individual service landing pages: `/services/1-day-app`, `/services/consulting`, `/services/training`
- 1-Day App Builds listed first across all service listings
- Updated nav: Services, Products, About

Closes #92

## Test plan
- [ ] Verify homepage renders all 5 sections correctly
- [ ] Verify `/services` lists 1-Day App Builds first, followed by Consulting and Training
- [ ] Verify each service landing page loads: `/services/1-day-app`, `/services/consulting`, `/services/training`
- [ ] Verify `/products` page shows featured products and project listings
- [ ] Verify navigation links work (Services → /services, Products → /products, About → /about)
- [ ] Verify CTA buttons (Calendly, Stripe) link correctly
- [ ] Test responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)